### PR TITLE
Adjust grid width for side buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,11 @@
       <div class="frame">
         <div class="grid-container">
           <div class="canvas">
-            <div id="grid" class="grid"></div>
+            <div class="grid-wrapper">
+              <div class="grid-overflow">
+                <div id="grid" class="grid"></div>
+              </div>
+            </div>
           </div>
           <div class="expansion-controls">
             <div class="side-controls top-controls">

--- a/script.js
+++ b/script.js
@@ -45,7 +45,8 @@
   class SolarGrid {
     constructor() {
       this.gridEl        = document.getElementById('grid');
-      this.wrapper       = document.querySelector('.grid-container');
+      this.wrapper       = document.querySelector('.grid-wrapper');
+      this.overflower    = document.querySelector('.grid-overflow');
       this.colsIn        = document.getElementById('cols-input');
       this.rowsIn        = document.getElementById('rows-input');
       this.wIn           = document.getElementById('width-input');
@@ -339,9 +340,7 @@
   		// Maximale verfügbare Größe
   		// Buttons sind 30px breit + 10px margin links und rechts = 50px pro Seite
   		// Insgesamt 100px für beide Seiten abziehen
-  		const gridContainer = document.querySelector('.grid-container');
-  		const canvas = document.querySelector('.canvas');
-  		const maxWidth = canvas ? canvas.clientWidth - 100 : window.innerWidth - 200; // 50px links + 50px rechts für Buttons
+  		const maxWidth = this.wrapper.clientWidth - 100; // grid-wrapper Breite - 100px für Buttons
   		const maxHeight = window.innerHeight * 0.7 - 100; // 70vh - 100px
   		
   		// Berechne benötigte Gesamtgröße mit Original-Zellgrößen (inklusive Gaps)
@@ -365,9 +364,8 @@
   		document.documentElement.style.setProperty('--cell-width',  w + 'px');
   		document.documentElement.style.setProperty('--cell-height', h + 'px');
 
-  		// Grid-Größe direkt setzen
-  		this.gridEl.style.width  = `calc(${this.cols}*${w}px + ${(this.cols-1)*gap}px)`;
-  		this.gridEl.style.height = `calc(${this.rows}*${h}px + ${(this.rows-1)*gap}px)`;
+  		this.overflower.style.width  = `calc(${this.cols}*${w}px + ${(this.cols-1)*gap}px)`;
+  		this.overflower.style.height = `calc(${this.rows}*${h}px + ${(this.rows-1)*gap}px)`;
       
 		}
 

--- a/script.js
+++ b/script.js
@@ -45,8 +45,7 @@
   class SolarGrid {
     constructor() {
       this.gridEl        = document.getElementById('grid');
-      this.wrapper       = document.querySelector('.grid-wrapper');
-      this.overflower    = document.querySelector('.grid-overflow');
+      this.wrapper       = document.querySelector('.grid-container');
       this.colsIn        = document.getElementById('cols-input');
       this.rowsIn        = document.getElementById('rows-input');
       this.wIn           = document.getElementById('width-input');
@@ -338,8 +337,11 @@
   		const originalCellH = isVertical ? inputW : inputH;
   		
   		// Maximale verfügbare Größe
-  		const parentElement = this.wrapper.parentElement;
-  		const maxWidth = parentElement.clientWidth - 100; // 100% des Parent - 100px
+  		// Buttons sind 30px breit + 10px margin links und rechts = 50px pro Seite
+  		// Insgesamt 100px für beide Seiten abziehen
+  		const gridContainer = document.querySelector('.grid-container');
+  		const canvas = document.querySelector('.canvas');
+  		const maxWidth = canvas ? canvas.clientWidth - 100 : window.innerWidth - 200; // 50px links + 50px rechts für Buttons
   		const maxHeight = window.innerHeight * 0.7 - 100; // 70vh - 100px
   		
   		// Berechne benötigte Gesamtgröße mit Original-Zellgrößen (inklusive Gaps)
@@ -359,11 +361,13 @@
   		const h = originalCellH * scale;
 
   		// CSS Variablen setzen
+  		document.documentElement.style.setProperty('--cell-size', w + 'px');
   		document.documentElement.style.setProperty('--cell-width',  w + 'px');
   		document.documentElement.style.setProperty('--cell-height', h + 'px');
 
-  		this.overflower.style.width  = `calc(${this.cols}*${w}px + ${(this.cols-1)*gap}px)`;
-  		this.overflower.style.height = `calc(${this.rows}*${h}px + ${(this.rows-1)*gap}px)`;
+  		// Grid-Größe direkt setzen
+  		this.gridEl.style.width  = `calc(${this.cols}*${w}px + ${(this.cols-1)*gap}px)`;
+  		this.gridEl.style.height = `calc(${this.rows}*${h}px + ${(this.rows-1)*gap}px)`;
       
 		}
 

--- a/style.css
+++ b/style.css
@@ -119,6 +119,21 @@ body {
   align-items: center;
 }
 
+.grid-wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.grid-overflow {
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .grid {
   display: grid;
   gap: var(--cell-gap);


### PR DESCRIPTION
Adjust grid width calculation to prevent overlap with buttons by using `grid-wrapper` and `grid-overflow` elements.

The user explicitly requested that the `grid-wrapper` and `grid-overflow` elements, which were previously removed/misunderstood, should exist and be used for the grid's sizing. The grid's maximum width is now correctly calculated as the `grid-wrapper`'s width minus 100px (50px for the buttons on each side), ensuring it fits within the available space.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a0cdda45-6fd1-4fd0-b0c4-8c634bd55165) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a0cdda45-6fd1-4fd0-b0c4-8c634bd55165)