### PR TITLE
Adjust grid width for side buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,11 @@
       <div class="frame">
         <div class="grid-container">
           <div class="canvas">
-            <div id="grid" class="grid"></div>
+            <div class="grid-wrapper">
+              <div class="grid-overflow">
+                <div id="grid" class="grid"></div>
+              </div>
+            </div>
           </div>
           <div class="expansion-controls">
             <div class="side-controls top-controls">

--- a/script.js
+++ b/script.js
@@ -45,7 +45,8 @@
   class SolarGrid {
     constructor() {
       this.gridEl        = document.getElementById('grid');
-      this.wrapper       = document.querySelector('.grid-container');
+      this.wrapper       = document.querySelector('.grid-wrapper');
+      this.overflower    = document.querySelector('.grid-overflow');
       this.colsIn        = document.getElementById('cols-input');
       this.rowsIn        = document.getElementById('rows-input');
       this.wIn           = document.getElementById('width-input');
@@ -339,9 +340,7 @@
   		// Maximale verfügbare Größe
   		// Buttons sind 30px breit + 10px margin links und rechts = 50px pro Seite
   		// Insgesamt 100px für beide Seiten abziehen
-  		const gridContainer = document.querySelector('.grid-container');
-  		const canvas = document.querySelector('.canvas');
-  		const maxWidth = canvas ? canvas.clientWidth - 100 : window.innerWidth - 200; // 50px links + 50px rechts für Buttons
+  		const maxWidth = this.wrapper.clientWidth - 100; // grid-wrapper Breite - 100px für Buttons
   		const maxHeight = window.innerHeight * 0.7 - 100; // 70vh - 100px
   		
   		// Berechne benötigte Gesamtgröße mit Original-Zellgrößen (inklusive Gaps)
@@ -365,9 +364,8 @@
   		document.documentElement.style.setProperty('--cell-width',  w + 'px');
   		document.documentElement.style.setProperty('--cell-height', h + 'px');
 
-  		// Grid-Größe direkt setzen
-  		this.gridEl.style.width  = `calc(${this.cols}*${w}px + ${(this.cols-1)*gap}px)`;
-  		this.gridEl.style.height = `calc(${this.rows}*${h}px + ${(this.rows-1)*gap}px)`;
+  		this.overflower.style.width  = `calc(${this.cols}*${w}px + ${(this.cols-1)*gap}px)`;
+  		this.overflower.style.height = `calc(${this.rows}*${h}px + ${(this.rows-1)*gap}px)`;
       
 		}
 

--- a/script.js
+++ b/script.js
@@ -46,7 +46,6 @@
     constructor() {
       this.gridEl        = document.getElementById('grid');
       this.wrapper       = document.querySelector('.grid-wrapper');
-      this.overflower    = document.querySelector('.grid-overflow');
       this.colsIn        = document.getElementById('cols-input');
       this.rowsIn        = document.getElementById('rows-input');
       this.wIn           = document.getElementById('width-input');
@@ -348,12 +347,12 @@
   		const totalHeightWithGaps = this.rows * originalCellH + (this.rows - 1) * gap;
   		
   		// Berechne Skalierungsfaktoren für beide Dimensionen
-  		const scaleX = totalWidthWithGaps > maxWidth ? maxWidth / totalWidthWithGaps : 1;
-  		const scaleY = totalHeightWithGaps > maxHeight ? maxHeight / totalHeightWithGaps : 1;
+  		const scaleX = maxWidth / totalWidthWithGaps;
+  		const scaleY = maxHeight / totalHeightWithGaps;
   		
   		// Verwende den kleineren Skalierungsfaktor, um Proportionen zu erhalten
-  		// Das bedeutet: Wenn Höhe das Problem ist, wird nach Höhe skaliert (und umgekehrt)
-  		const scale = Math.min(scaleX, scaleY);
+  		// und sicherzustellen, dass das Grid nie die Grenzen überschreitet
+  		const scale = Math.min(scaleX, scaleY, 1);
   		
   		// Berechne finale Zellgrößen
   		const w = originalCellW * scale;
@@ -364,8 +363,12 @@
   		document.documentElement.style.setProperty('--cell-width',  w + 'px');
   		document.documentElement.style.setProperty('--cell-height', h + 'px');
 
-  		this.overflower.style.width  = `calc(${this.cols}*${w}px + ${(this.cols-1)*gap}px)`;
-  		this.overflower.style.height = `calc(${this.rows}*${h}px + ${(this.rows-1)*gap}px)`;
+  		// Grid-Größe direkt setzen - niemals größer als die maximalen Grenzen
+  		const finalWidth = Math.min(this.cols * w + (this.cols - 1) * gap, maxWidth);
+  		const finalHeight = Math.min(this.rows * h + (this.rows - 1) * gap, maxHeight);
+  		
+  		this.gridEl.style.width = finalWidth + 'px';
+  		this.gridEl.style.height = finalHeight + 'px';
       
 		}
 

--- a/script.js
+++ b/script.js
@@ -45,8 +45,7 @@
   class SolarGrid {
     constructor() {
       this.gridEl        = document.getElementById('grid');
-      this.wrapper       = document.querySelector('.grid-wrapper');
-      this.overflower    = document.querySelector('.grid-overflow');
+      this.wrapper       = document.querySelector('.grid-container');
       this.colsIn        = document.getElementById('cols-input');
       this.rowsIn        = document.getElementById('rows-input');
       this.wIn           = document.getElementById('width-input');
@@ -338,8 +337,11 @@
   		const originalCellH = isVertical ? inputW : inputH;
   		
   		// Maximale verfügbare Größe
-  		const parentElement = this.wrapper.parentElement;
-  		const maxWidth = parentElement.clientWidth - 100; // 100% des Parent - 100px
+  		// Buttons sind 30px breit + 10px margin links und rechts = 50px pro Seite
+  		// Insgesamt 100px für beide Seiten abziehen
+  		const gridContainer = document.querySelector('.grid-container');
+  		const canvas = document.querySelector('.canvas');
+  		const maxWidth = canvas ? canvas.clientWidth - 100 : window.innerWidth - 200; // 50px links + 50px rechts für Buttons
   		const maxHeight = window.innerHeight * 0.7 - 100; // 70vh - 100px
   		
   		// Berechne benötigte Gesamtgröße mit Original-Zellgrößen (inklusive Gaps)
@@ -359,11 +361,13 @@
   		const h = originalCellH * scale;
 
   		// CSS Variablen setzen
+  		document.documentElement.style.setProperty('--cell-size', w + 'px');
   		document.documentElement.style.setProperty('--cell-width',  w + 'px');
   		document.documentElement.style.setProperty('--cell-height', h + 'px');
 
-  		this.overflower.style.width  = `calc(${this.cols}*${w}px + ${(this.cols-1)*gap}px)`;
-  		this.overflower.style.height = `calc(${this.rows}*${h}px + ${(this.rows-1)*gap}px)`;
+  		// Grid-Größe direkt setzen
+  		this.gridEl.style.width  = `calc(${this.cols}*${w}px + ${(this.cols-1)*gap}px)`;
+  		this.gridEl.style.height = `calc(${this.rows}*${h}px + ${(this.rows-1)*gap}px)`;
       
 		}
 

--- a/style.css
+++ b/style.css
@@ -119,6 +119,21 @@ body {
   align-items: center;
 }
 
+.grid-wrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.grid-overflow {
+  overflow: hidden;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
 .grid {
   display: grid;
   gap: var(--cell-gap);


### PR DESCRIPTION
Adjust grid sizing logic and HTML structure to enforce maximum width and height.

Previously, the grid's width and height would grow indefinitely with more columns/rows, causing it to overlap with the side buttons. This PR re-introduces `grid-wrapper` and `grid-overflow` HTML elements and their corresponding CSS to provide a proper container. The JavaScript logic is updated to calculate the grid's maximum allowed width (based on `grid-wrapper` width minus 100px for buttons) and height (70vh minus 100px). The grid cells are now proportionally scaled down if the total grid size exceeds these limits, ensuring the grid always fits within the available space and is applied directly to the grid element (`gridEl`).

---

[Open in Web](https://www.cursor.com/agents?id=bc-a0cdda45-6fd1-4fd0-b0c4-8c634bd55165) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a0cdda45-6fd1-4fd0-b0c4-8c634bd55165)