### PR TITLE
Adjust grid width for side buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -337,10 +337,10 @@
   		const originalCellH = isVertical ? inputW : inputH;
   		
   		// Maximale verfügbare Größe
-  		// Buttons sind 30px breit + 10px margin links und rechts = 50px pro Seite
-  		// Insgesamt 100px für beide Seiten abziehen
-  		const maxWidth = this.wrapper.clientWidth - 100; // grid-wrapper Breite - 100px für Buttons
-  		const maxHeight = this.wrapper.clientHeight - 100; // 70vh - 100px
+  		// 50px Abstand auf allen Seiten: links, rechts, oben, unten
+  		// Insgesamt 100px für Breite (50px links + 50px rechts) und 100px für Höhe (50px oben + 50px unten)
+  		const maxWidth = this.wrapper.clientWidth - 100; // grid-wrapper Breite - 100px (50px links + 50px rechts)
+  		const maxHeight = this.wrapper.clientHeight - 100; // grid-wrapper Höhe - 100px (50px oben + 50px unten)
   		
   		// Berechne benötigte Gesamtgröße mit Original-Zellgrößen (inklusive Gaps für Schienen)
   		const totalWidthWithRailGaps = this.cols * originalCellW + (this.cols - 1) * RAIL_GAP;
@@ -375,16 +375,6 @@
   		
   		this.gridEl.style.width = finalWidth + 'px';
   		this.gridEl.style.height = finalHeight + 'px';
-
-  		const railGap = 2; // Schienen-Gap ist immer 2cm
-  		const totalWidthWithRailGaps = this.cols * originalCellW + (this.cols - 1) * railGap;
-  		const totalHeightWithRailGaps = this.rows * originalCellH + (this.rows - 1) * railGap;
-
-  		const isAtMaxWidth = totalWidthWithRailGaps * scale >= maxWidth;
-  		const isAtMaxHeight = totalHeightWithRailGaps * scale >= maxHeight;
-  		const visualGap = (isAtMaxWidth || isAtMaxHeight) ? 0 : railGap * scale;
-
-  		document.documentElement.style.setProperty('--cell-gap', visualGap + 'px');
 		}
 
     buildGrid() {

--- a/script.js
+++ b/script.js
@@ -324,7 +324,7 @@
     
 
     updateSize() {
-  		const railGap = 2; // Immer 2cm für Schienen-Berechnungen
+  		const RAIL_GAP = 2; // Immer 2cm für Schienen-Berechnungen
   		const remPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
 
   		// Original Zellengrößen aus Input - bei Orientierung entsprechend anwenden
@@ -343,8 +343,8 @@
   		const maxHeight = this.wrapper.clientHeight - 100; // 70vh - 100px
   		
   		// Berechne benötigte Gesamtgröße mit Original-Zellgrößen (inklusive Gaps für Schienen)
-  		const totalWidthWithRailGaps = this.cols * originalCellW + (this.cols - 1) * railGap;
-  		const totalHeightWithRailGaps = this.rows * originalCellH + (this.rows - 1) * railGap;
+  		const totalWidthWithRailGaps = this.cols * originalCellW + (this.cols - 1) * RAIL_GAP;
+  		const totalHeightWithRailGaps = this.rows * originalCellH + (this.rows - 1) * RAIL_GAP;
   		
   		// Berechne Skalierungsfaktoren für beide Dimensionen
   		const scaleX = maxWidth / totalWidthWithRailGaps;
@@ -358,10 +358,10 @@
   		const w = originalCellW * scale;
   		const h = originalCellH * scale;
 
-  		// Bestimme visuelle Gap: 0 wenn maximale Grenzen erreicht werden, sonst railGap * scale
+  		// Bestimme visuelle Gap: 0 wenn maximale Grenzen erreicht werden, sonst RAIL_GAP * scale
   		const isAtMaxWidth = totalWidthWithRailGaps * scale >= maxWidth;
   		const isAtMaxHeight = totalHeightWithRailGaps * scale >= maxHeight;
-  		const visualGap = (isAtMaxWidth || isAtMaxHeight) ? 0 : railGap * scale;
+  		const visualGap = (isAtMaxWidth || isAtMaxHeight) ? 0 : RAIL_GAP * scale;
 
   		// CSS Variablen setzen
   		document.documentElement.style.setProperty('--cell-size', w + 'px');


### PR DESCRIPTION
Refactor grid sizing and gap handling to respect margins and fix syntax errors.

The grid was exceeding its intended boundaries and overlapping with surrounding elements. This PR ensures the grid maintains a 50px margin on all sides relative to its wrapper, dynamically scales cell sizes, and makes the visual gap disappear when maximum dimensions are reached, while keeping a constant gap for internal rail calculations. It also cleans up duplicate variable declarations that caused runtime errors.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a0cdda45-6fd1-4fd0-b0c4-8c634bd55165) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a0cdda45-6fd1-4fd0-b0c4-8c634bd55165)