### PR TITLE
Adjust grid width for side buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -358,10 +358,10 @@
   		const w = originalCellW * scale;
   		const h = originalCellH * scale;
 
-  		// Bestimme visuelle Gap: 0 wenn maximale Grenzen erreicht werden, sonst RAIL_GAP * scale
-  		const isAtMaxWidth = totalWidthWithRailGaps * scale >= maxWidth;
-  		const isAtMaxHeight = totalHeightWithRailGaps * scale >= maxHeight;
-  		const visualGap = (isAtMaxWidth || isAtMaxHeight) ? 0 : RAIL_GAP * scale;
+  		// Bestimme visuelle Gap: 0 wenn viele Spalten/Zeilen, sonst RAIL_GAP * scale
+  		// Gap verschwindet horizontal ab 15 Spalten, vertikal ab 10 Zeilen
+  		const shouldHideGap = this.cols >= 15 || this.rows >= 10;
+  		const visualGap = shouldHideGap ? 0 : RAIL_GAP * scale;
 
   		// CSS Variablen setzen
   		document.documentElement.style.setProperty('--cell-size', w + 'px');

--- a/script.js
+++ b/script.js
@@ -337,10 +337,10 @@
   		const originalCellH = isVertical ? inputW : inputH;
   		
   		// Maximale verfügbare Größe
-  		// Buttons sind 30px breit + 10px margin links und rechts = 50px pro Seite
-  		// Insgesamt 100px für beide Seiten abziehen
-  		const maxWidth = this.wrapper.clientWidth - 100; // grid-wrapper Breite - 100px für Buttons
-  		const maxHeight = this.wrapper.clientHeight - 100; // 70vh - 100px
+  		// 50px Abstand auf allen Seiten: links, rechts, oben, unten
+  		// Insgesamt 100px für Breite (50px links + 50px rechts) und 100px für Höhe (50px oben + 50px unten)
+  		const maxWidth = this.wrapper.clientWidth - 100; // grid-wrapper Breite - 100px (50px links + 50px rechts)
+  		const maxHeight = this.wrapper.clientHeight - 100; // grid-wrapper Höhe - 100px (50px oben + 50px unten)
   		
   		// Berechne benötigte Gesamtgröße mit Original-Zellgrößen (inklusive Gaps für Schienen)
   		const totalWidthWithRailGaps = this.cols * originalCellW + (this.cols - 1) * RAIL_GAP;
@@ -375,16 +375,6 @@
   		
   		this.gridEl.style.width = finalWidth + 'px';
   		this.gridEl.style.height = finalHeight + 'px';
-
-  		const railGap = 2; // Schienen-Gap ist immer 2cm
-  		const totalWidthWithRailGaps = this.cols * originalCellW + (this.cols - 1) * railGap;
-  		const totalHeightWithRailGaps = this.rows * originalCellH + (this.rows - 1) * railGap;
-
-  		const isAtMaxWidth = totalWidthWithRailGaps * scale >= maxWidth;
-  		const isAtMaxHeight = totalHeightWithRailGaps * scale >= maxHeight;
-  		const visualGap = (isAtMaxWidth || isAtMaxHeight) ? 0 : railGap * scale;
-
-  		document.documentElement.style.setProperty('--cell-gap', visualGap + 'px');
 		}
 
     buildGrid() {

--- a/script.js
+++ b/script.js
@@ -324,7 +324,7 @@
     
 
     updateSize() {
-  		const railGap = 2; // Immer 2cm für Schienen-Berechnungen
+  		const RAIL_GAP = 2; // Immer 2cm für Schienen-Berechnungen
   		const remPx = parseFloat(getComputedStyle(document.documentElement).fontSize);
 
   		// Original Zellengrößen aus Input - bei Orientierung entsprechend anwenden
@@ -343,8 +343,8 @@
   		const maxHeight = this.wrapper.clientHeight - 100; // 70vh - 100px
   		
   		// Berechne benötigte Gesamtgröße mit Original-Zellgrößen (inklusive Gaps für Schienen)
-  		const totalWidthWithRailGaps = this.cols * originalCellW + (this.cols - 1) * railGap;
-  		const totalHeightWithRailGaps = this.rows * originalCellH + (this.rows - 1) * railGap;
+  		const totalWidthWithRailGaps = this.cols * originalCellW + (this.cols - 1) * RAIL_GAP;
+  		const totalHeightWithRailGaps = this.rows * originalCellH + (this.rows - 1) * RAIL_GAP;
   		
   		// Berechne Skalierungsfaktoren für beide Dimensionen
   		const scaleX = maxWidth / totalWidthWithRailGaps;
@@ -358,10 +358,10 @@
   		const w = originalCellW * scale;
   		const h = originalCellH * scale;
 
-  		// Bestimme visuelle Gap: 0 wenn maximale Grenzen erreicht werden, sonst railGap * scale
+  		// Bestimme visuelle Gap: 0 wenn maximale Grenzen erreicht werden, sonst RAIL_GAP * scale
   		const isAtMaxWidth = totalWidthWithRailGaps * scale >= maxWidth;
   		const isAtMaxHeight = totalHeightWithRailGaps * scale >= maxHeight;
-  		const visualGap = (isAtMaxWidth || isAtMaxHeight) ? 0 : railGap * scale;
+  		const visualGap = (isAtMaxWidth || isAtMaxHeight) ? 0 : RAIL_GAP * scale;
 
   		// CSS Variablen setzen
   		document.documentElement.style.setProperty('--cell-size', w + 'px');


### PR DESCRIPTION
Adjust grid sizing to respect 50px margins on all sides and refine cell gap visibility logic.

The grid now correctly fits within `this.wrapper` by subtracting 100px from both width and height (50px per side). The visual gap between cells now disappears when the grid has 15 or more columns, or 10 or more rows, while the underlying rail calculations consistently use a 2cm gap. This also cleans up duplicate variable declarations in `updateSize()`.

---

[Open in Web](https://www.cursor.com/agents?id=bc-a0cdda45-6fd1-4fd0-b0c4-8c634bd55165) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a0cdda45-6fd1-4fd0-b0c4-8c634bd55165)